### PR TITLE
Removed class `max-h-screen` from `ListLayoutWithTags`

### DIFF
--- a/layouts/ListLayoutWithTags.tsx
+++ b/layouts/ListLayoutWithTags.tsx
@@ -84,7 +84,7 @@ export default function ListLayoutWithTags({
           </h1>
         </div>
         <div className="flex sm:space-x-24">
-          <div className="hidden h-full max-h-screen min-w-[280px] max-w-[280px] flex-wrap overflow-auto rounded bg-gray-50 pt-5 shadow-md dark:bg-gray-900/70 dark:shadow-gray-800/40 sm:flex">
+          <div className="hidden h-full min-w-[280px] max-w-[280px] flex-wrap overflow-auto rounded bg-gray-50 pt-5 shadow-md dark:bg-gray-900/70 dark:shadow-gray-800/40 sm:flex">
             <div className="px-6 py-4">
               {pathname.startsWith('/blog') ? (
                 <h3 className="font-bold uppercase text-primary-500">All Posts</h3>


### PR DESCRIPTION

![CleanShot-2024-08-22@15 27 14@2x](https://github.com/user-attachments/assets/7e75cc39-c046-4634-a353-f137ec7fa8e6)
The tag items would overflow their container if there are too many of them. Removed the `max-h-screen` class to prevent the overflow.